### PR TITLE
Slash in keys

### DIFF
--- a/JsonPointer.php
+++ b/JsonPointer.php
@@ -47,7 +47,7 @@ class JsonPointer
         if ($pointer === self::POINTER_CHAR) {
             return json_encode($this->json);
         }
-        $plainPointerParts = array_slice(explode('/', $pointer), 1);
+        $plainPointerParts = array_slice(array_map("urldecode", explode('/', $pointer)), 1);
 
         $overwrite = false;
         if ($value === null) {

--- a/JsonPointerTest.php
+++ b/JsonPointerTest.php
@@ -260,6 +260,18 @@ class JsonPointerTest extends PHPUnit_Framework_TestCase
         $this->assertSame(1521, $jsonPointer->get('/test%2Ffoo.txt/size'));
     }
     /**
+     * @test
+     */
+    public function setShouldReplaceValueOfPointerWithSlashInKey()
+    {
+        $givenJson = '{"test/foo.txt":{"size":1521,"description":"Text File"}}';
+        $jsonPointer = new JsonPointer($givenJson);
+        $jsonPointer->set('/test%2Ffoo.txt/size', 2222);
+        $pointedJson = $jsonPointer->get('/');
+        $pointedData = json_decode($pointedJson);
+        $this->assertSame(2222, $pointedData->{'test/foo.txt'}->{'size'});
+    }
+    /**
      * @return array
      */
     public function nonStringPointerProvider()


### PR DESCRIPTION
Hi - glad to see support for JSONPointer! One thing that it supports is for keys to contain anything, including a forward slash. It works by the JSONPath being URL encoded before it's joined ("doc/json.md" -> "doc%2Fjson.md") and decoding after it's split. I added a couple of tests and made it do the URL decode to each element of the array after splitting it.
