### PR TITLE
fix how we check for object attributes.. 

### DIFF
--- a/src/Rs/Json/Pointer.php
+++ b/src/Rs/Json/Pointer.php
@@ -92,7 +92,7 @@ class Pointer
             if (is_array($json[$pointerPart]) && is_array($pointerParts)) {
                 return $this->traverse($json[$pointerPart], $pointerParts);
             }
-        } elseif (is_object($json) && array_key_exists($pointerPart, get_object_vars($json))) {
+        } elseif (is_object($json) && in_array($pointerPart, array_keys(get_object_vars($json)))) {
             if (count($pointerParts) === 0) {
                 return $json->{$pointerPart};
             }


### PR DESCRIPTION
somehow the old approach was behaving different in some cases where we had access keys like '3' (int as string) in php7

fix needed for raphaelstolt/php-jsonpatch#36